### PR TITLE
Improve error types

### DIFF
--- a/blueprint/cli/blueprints/controller/crud/controller.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/crud/controller.rs.liquid.liquid
@@ -1,36 +1,29 @@
-use crate::{internal_error, state::AppState};
+use crate::{error::Error, state::AppState};
 use axum::{extract::Path, extract::State, http::StatusCode, Json};
-use {{db_crate_name}}::{entities, Error};
+use {{db_crate_name}}::entities;
 use tracing::info;
 use uuid::Uuid;
 
 pub async fn create(
     State(app_state): State<AppState>,
     Json({{entity_singular_name}}): Json<() /* e.g.entities::{{entity_plural_name}}::{{entity_struct_name}}Changeset */>,
-) -> Result<() /* e.g. (StatusCode, Json<entities::{{entity_plural_name}}::{{entity_struct_name}}>) */, (StatusCode, String)> {
+) -> Result<() /* e.g. (StatusCode, Json<entities::{{entity_plural_name}}::{{entity_struct_name}}>) */, Error> {
     todo!("create resource via {{db_crate_name}}'s APIs, trace, and respond!")
 
     /* Example:
-    match entities::{{entity_plural_name}}::create({{entity_singular_name}}, &app_state.db_pool).await {
-        Ok({{entity_singular_name}}) => Ok((StatusCode::CREATED, Json({{entity_singular_name}}))),
-        Err(Error::ValidationError(e)) => {
-            info!(err.msg = %e, err.details = ?e, "Validation failed");
-            Err((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))
-        }
-        Err(e) => Err((internal_error(e), "".into())),
-    }
+    let {{entity_singular_name}} = entities::{{entity_plural_name}}::create({{entity_singular_name}}, &app_state.db_pool).await?;
+    Ok((StatusCode::CREATED, Json({{entity_singular_name}})))
     */
 }
 
 pub async fn read_all(
     State(app_state): State<AppState>,
-) -> Result<() /* e.g. Json<Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}>> */, StatusCode> {
+) -> Result<() /* e.g. Json<Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}>> */, Error> {
     todo!("load resources via {{db_crate_name}}'s APIs, trace, and respond!")
 
     /* Example:
     let {{entity_plural_name}} = entities::{{entity_plural_name}}::load_all(&app_state.db_pool)
-        .await
-        .map_err(internal_error)?;
+        .await?;
 
     info!("responding with {:?}", {{entity_plural_name}});
 
@@ -41,15 +34,12 @@ pub async fn read_all(
 pub async fn read_one(
     State(app_state): State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<() /* e.g. Json<entities::{{entity_plural_name}}::{{entity_struct_name}}> */, StatusCode> {
+) -> Result<() /* e.g. Json<entities::{{entity_plural_name}}::{{entity_struct_name}}> */, Error> {
     todo!("load resource via {{db_crate_name}}'s APIs, trace, and respond!")
 
     /* Example:
-    match entities::{{entity_plural_name}}::load(id, &app_state.db_pool).await {
-        Ok({{entity_singular_name}}) => Ok(Json({{entity_singular_name}})),
-        Err(Error::NoRecordFound) => Err(StatusCode::NOT_FOUND),
-        Err(e) => Err(internal_error(e)),
-    }
+    let {{entity_singular_name}} = entities::{{entity_plural_name}}::load(id, &app_state.db_pool).await?;
+    Ok(Json({{entity_singular_name}}))
     */
 }
 
@@ -57,33 +47,23 @@ pub async fn update(
     State(app_state): State<AppState>,
     Path(id): Path<Uuid>,
     Json({{entity_singular_name}}): Json<() /* e.g. entities::{{entity_plural_name}}::{{entity_struct_name}}Changeset */>,
-) -> Result<() /* e.g. Json<entities::{{entity_plural_name}}::{{entity_struct_name}}> */, (StatusCode, String)> {
+) -> Result<() /* e.g. Json<entities::{{entity_plural_name}}::{{entity_struct_name}}> */, Error> {
     todo!("update resource via {{db_crate_name}}'s APIs, trace, and respond!")
 
     /* Example:
-    match entities::{{entity_plural_name}}::update(id, {{entity_singular_name}}, &app_state.db_pool).await {
-        Ok({{entity_singular_name}}) => Ok(Json({{entity_singular_name}})),
-        Err(Error::NoRecordFound) => Err((StatusCode::NOT_FOUND, "".into())),
-        Err(Error::ValidationError(e)) => {
-            info!(err.msg = %e, err.details = ?e, "Validation failed");
-            Err((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))
-        }
-        Err(e) => Err((internal_error(e), "".into())),
-    }
+    let {{entity_singular_name}} = entities::{{entity_plural_name}}::update(id, {{entity_singular_name}}, &app_state.db_pool).await?;
+    Ok(Json({{entity_singular_name}}))
     */
 }
 
 pub async fn delete(
     State(app_state): State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<StatusCode, Error> {
     todo!("delete resource via {{db_crate_name}}'s APIs, trace, and respond!")
 
     /* Example:
-    match entities::{{entity_plural_name}}::delete(id, &app_state.db_pool).await {
-        Ok(_) => Ok(StatusCode::NO_CONTENT),
-        Err(Error::NoRecordFound) => Err((StatusCode::NOT_FOUND, "".into())),
-        Err(e) => Err((internal_error(e), "".into())),
-    }
+    entities::{{entity_plural_name}}::delete(id, &app_state.db_pool).await?;
+    Ok(StatusCode::NO_CONTENT)
     */
 }

--- a/blueprint/cli/blueprints/controller/minimal/controller.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/minimal/controller.rs.liquid.liquid
@@ -1,8 +1,8 @@
-use crate::{internal_error, state::AppState};
+use crate::{error::Error, state::AppState};
 use axum::{extract::State, http::StatusCode};
 use tracing::info;
 
-pub async fn action(State(app_state): State<AppState>) -> Result<StatusCode, (StatusCode, String)> {
+pub async fn action(State(app_state): State<AppState>) -> Result<StatusCode, Error> {
     todo!("implement!");
 
     info!("responding with {:?}", StatusCode::OK);

--- a/blueprint/cli/blueprints/entity/file.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/entity/file.rs.liquid.liquid
@@ -24,8 +24,8 @@ pub struct {{entity_struct_name}}Changeset {
 
 pub async fn load_all(
     executor: impl sqlx::Executor<'_, Database = Postgres>,
-) -> Result<Vec<{{entity_struct_name}}>, anyhow::Error> {
-    todo!("Adopt the SQL query as necessary!");
+) -> Result<Vec<{{entity_struct_name}}>, crate::Error> {
+    todo!("Adapt the SQL query as necessary!");
     let {{entity_plural_name}} = sqlx::query_as!({{entity_struct_name}}, "SELECT id, name FROM {{entity_plural_name}}")
         .fetch_all(executor)
         .await?;
@@ -36,7 +36,7 @@ pub async fn load(
     id: Uuid,
     executor: impl sqlx::Executor<'_, Database = Postgres>,
 ) -> Result<{{entity_struct_name}}, crate::Error> {
-    todo!("Adopt the SQL query as necessary!");
+    todo!("Adapt the SQL query as necessary!");
     match sqlx::query_as!(
         {{entity_struct_name}},
         "SELECT id, description FROM {{entity_plural_name}} WHERE id = $1",
@@ -44,7 +44,7 @@ pub async fn load(
     )
     .fetch_optional(executor)
     .await
-    .map_err(|e| crate::Error::DbError(e.into()))?
+    .map_err(crate::Error::DbError)?
     {
         Some({{entity_singular_name}}) => Ok({{entity_singular_name}}),
         None => Err(crate::Error::NoRecordFound),
@@ -57,14 +57,14 @@ pub async fn create(
 ) -> Result<{{entity_struct_name}}, crate::Error> {
     {{entity_singular_name}}.validate().map_err(crate::Error::ValidationError)?;
 
-    todo!("Adopt the SQL query and bound parameters as necessary!");
+    todo!("Adapt the SQL query and bound parameters as necessary!");
     let record = sqlx::query!(
         "INSERT INTO {{entity_plural_name}} (name) VALUES ($1) RETURNING id",
         {{entity_singular_name}}.name
     )
     .fetch_one(executor)
     .await
-    .map_err(|e| crate::Error::DbError(e.into()))?;
+    .map_err(crate::Error::DbError)?;
 
     Ok({{entity_struct_name}} {
         id: record.id,
@@ -79,7 +79,7 @@ pub async fn update(
 ) -> Result<{{entity_struct_name}}, crate::Error> {
     {{entity_singular_name}}.validate().map_err(crate::Error::ValidationError)?;
 
-    todo!("Adopt the SQL query and bound parameters as necessary!");
+    todo!("Adapt the SQL query and bound parameters as necessary!");
     match sqlx::query!(
         "UPDATE {{entity_plural_name}} SET name = $1 WHERE id = $2 RETURNING id, name",
         {{entity_singular_name}}.name,
@@ -87,7 +87,7 @@ pub async fn update(
     )
     .fetch_optional(executor)
     .await
-    .map_err(|e| crate::Error::DbError(e.into()))?
+    .map_err(crate::Error::DbError)?
     {
         Some(record) => Ok({{entity_struct_name}} {
             id: record.id,
@@ -101,11 +101,11 @@ pub async fn delete(
     id: Uuid,
     executor: impl sqlx::Executor<'_, Database = Postgres>,
 ) -> Result<(), crate::Error> {
-    todo!("Adopt the SQL query as necessary!");
+    todo!("Adapt the SQL query as necessary!");
     match sqlx::query!("DELETE FROM {{entity_plural_name}} WHERE id = $1 RETURNING id", id)
         .fetch_optional(executor)
         .await
-        .map_err(|e| crate::Error::DbError(e.into()))?
+        .map_err(crate::Error::DbError)?
     {
         Some(_) => Ok(()),
         None => Err(crate::Error::NoRecordFound),

--- a/blueprint/db/src/entities/tasks.rs
+++ b/blueprint/db/src/entities/tasks.rs
@@ -36,7 +36,7 @@ pub struct TaskChangeset {
 /// Load all [`Task`]s from the database.
 pub async fn load_all(
     executor: impl sqlx::Executor<'_, Database = Postgres>,
-) -> Result<Vec<Task>, anyhow::Error> {
+) -> Result<Vec<Task>, crate::Error> {
     let tasks = sqlx::query_as!(Task, "SELECT id, description FROM tasks")
         .fetch_all(executor)
         .await?;
@@ -53,7 +53,7 @@ pub async fn load(
     sqlx::query_as!(Task, "SELECT id, description FROM tasks WHERE id = $1", id)
         .fetch_optional(executor)
         .await
-        .map_err(|e| crate::Error::DbError(e.into()))?
+        .map_err(crate::Error::DbError)?
         .ok_or(crate::Error::NoRecordFound)
 }
 
@@ -67,7 +67,7 @@ pub async fn delete(
     sqlx::query!("DELETE FROM tasks WHERE id = $1 RETURNING id", id)
         .fetch_optional(executor)
         .await
-        .map_err(|e| crate::Error::DbError(e.into()))?
+        .map_err(crate::Error::DbError)?
         .ok_or(crate::Error::NoRecordFound)?;
     
     Ok(())
@@ -88,7 +88,7 @@ pub async fn create(
     )
     .fetch_one(executor)
     .await
-    .map_err(|e| crate::Error::DbError(e.into()))?;
+    .map_err(crate::Error::DbError)?;
 
     Ok(Task {
         id: record.id,
@@ -113,7 +113,7 @@ pub async fn update(
     )
     .fetch_optional(executor)
     .await
-    .map_err(|e| crate::Error::DbError(e.into()))?
+    .map_err(crate::Error::DbError)?
     .ok_or(crate::Error::NoRecordFound)
     .map(|record| Task {
         id: record.id,

--- a/blueprint/db/src/lib.rs
+++ b/blueprint/db/src/lib.rs
@@ -41,13 +41,16 @@ pub async fn transaction(
 pub enum Error {
     /// General database error, e.g. communicating with the database failed
     #[error("database query failed")]
-    DbError(anyhow::Error),
-    /// No record was found where one was expected, e.g. when loading a record by ID
-    #[error("no record found where one was expected")]
+    DbError(#[from] sqlx::Error),
+    /// No record was found, e.g. when loading a record by ID. This variant is different from
+    /// `Error::DbError(sqlx::Error::RowNotFound)`, in that the latter indicates a bug, and
+    /// `Error::NoRecordFound` does not. It merely originates from [sqlx::Executor::fetch_optional]
+    /// returning `None`.
+    #[error("no record found")]
     NoRecordFound,
     #[error("validation failed")]
     /// An invalid changeset was passed to a writing operation such as creating or updating a record.
-    ValidationError(validator::ValidationErrors),
+    ValidationError(#[from] validator::ValidationErrors),
 }
 
 /// Creates a connection pool to the database specified in the passed [`{{project-name}}-config::DatabaseConfig`]

--- a/blueprint/db/src/lib.rs
+++ b/blueprint/db/src/lib.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[error("database query failed")]
     DbError(#[from] sqlx::Error),
     /// No record was found, e.g. when loading a record by ID. This variant is different from
-    /// `Error::DbError(sqlx::Error::RowNotFound)`, in that the latter indicates a bug, and
+    /// `Error::DbError(sqlx::Error::RowNotFound)` in that the latter indicates a bug, and
     /// `Error::NoRecordFound` does not. It merely originates from [sqlx::Executor::fetch_optional]
     /// returning `None`.
     #[error("no record found")]

--- a/blueprint/web/Cargo.toml.liquid
+++ b/blueprint/web/Cargo.toml.liquid
@@ -28,8 +28,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "f
 uuid = { version = "1.6", features = ["serde"] }
 {%- endunless %}
 serde_json = { version = "1.0", optional = true }
+thiserror = "1.0"
 tower = { version = "0.5", features = ["util"], optional = true }
 hyper = { version = "1.0", features = ["full"], optional = true }
+{% unless template_type == "minimal" -%}
+validator = "0.18"
+{%- endunless %}
 {{project-name}}-macros = { path = "../macros", optional = true }
 
 [dev-dependencies]

--- a/blueprint/web/src/error.rs.liquid
+++ b/blueprint/web/src/error.rs.liquid
@@ -1,0 +1,54 @@
+use axum::{http::StatusCode, response::IntoResponse};
+use std::fmt::{Debug, Display};
+
+/// Error type that encapsultes anything that can go wrong
+/// in this application. Implements [IntoResponse],
+/// so that it can be returned directly from a request handler.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+{% unless template_type == "minimal" -%}
+    /// Errors that can occur as a result of a data layer operation.
+    #[error("Database error")]
+    Database(#[from] {{crate_name}}_db::Error),
+{%- endunless %}
+    /// Any other error. Handled as an Internal Server Error.
+    #[error("Error: {0}")]
+    Other(#[from] anyhow::Error),
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+{% unless template_type == "minimal" -%}
+            Error::Database({{crate_name}}_db::Error::NoRecordFound) => StatusCode::NOT_FOUND.into_response(),
+            Error::Database({{crate_name}}_db::Error::ValidationError(e)) => validation_error(e).into_response(),
+            Error::Database({{crate_name}}_db::Error::DbError(e)) => internal_error(e).into_response(),
+{%- endunless %}
+            Error::Other(e) => internal_error(e).into_response(),
+        }
+    }
+}
+
+/// Helper function to create an internal error response while
+/// taking care to log the error itself.
+fn internal_error<E>(e: E) -> StatusCode
+where
+    // Some "error-like" types (e.g. `anyhow::Error`) don't implement the error trait, therefore
+    // we "downgrade" to simply requiring `Debug` and `Display`, the traits
+    // we actually need for logging purposes.
+    E: Debug + Display,
+{
+    tracing::error!(err.msg = %e, err.details = ?e, "Internal server error");
+    // We don't want to leak internal implementation details to the client
+    // via the error response, so we just return an opaque internal server.
+    StatusCode::INTERNAL_SERVER_ERROR
+}
+
+{% unless template_type == "minimal" -%}
+/// Helper function to create an unprocessable entity error response while
+/// taking care to log the error itself.
+fn validation_error(e: validator::ValidationErrors) -> (StatusCode, String) {
+    tracing::info!(err.msg = %e, err.details = ?e, "Validation failed");
+    (StatusCode::UNPROCESSABLE_ENTITY, e.to_string())
+}
+{%- endunless %}

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -1,9 +1,8 @@
 //! The {{crate_name}}_web crate contains the application's web interface which mainly are controllers implementing HTTP endpoints. It also includes the application tests that are black-box tests, interfacing with the application like any other HTTP client.
 
 use anyhow::Context;
-use axum::{serve, http::StatusCode};
+use axum::serve;
 use {{crate_name}}_config::{Config, get_env, load_config};
-use std::fmt::{Debug, Display};
 use tokio::net::TcpListener;
 use tracing::info;
 use tracing_panic::panic_hook;
@@ -17,6 +16,8 @@ pub mod middlewares;
 pub mod routes;
 /// Contains the application state definition and functionality to initialize it.
 pub mod state;
+/// Contains the application's error type and related conversion implementation.
+pub mod error;
 
 /// Runs the application.
 ///
@@ -40,40 +41,6 @@ pub async fn run() -> anyhow::Result<()> {
     serve(listener, app.into_make_service()).await?;
 
     Ok(())
-}
-
-/// Helper function to create an internal error response while
-/// taking care to log the error itself.
-///
-/// This is useful to avoid duplication in web endpoints – in the case of unrecoverable errors,
-/// there's only really two things to do anyway, which you'll want to do in every such case:
-///
-/// 1. create an error-level tracing event
-/// 2. respond with an axum::http::StatusCode::INTERNAL_SERVER_ERROR status code
-///
-/// Example
-/// ```rust
-/// pub async fn read_all(
-///     State(app_state): State<AppState>,
-/// ) -> Result<Json<Vec<Task>>, StatusCode> {
-///     let tasks = tasks::load_all(&app_state.db_pool)
-///         .await
-///         .map_err(internal_error)?;
-///
-///     Ok(Json(tasks))
-/// }
-/// ```
-pub fn internal_error<E>(e: E) -> StatusCode
-where
-    // Some "error-like" types (e.g. `anyhow::Error`) don't implement the error trait, therefore
-    // we "downgrade" to simply requiring `Debug` and `Display`, the traits
-    // we actually need for logging purposes.
-    E: Debug + Display,
-{
-    tracing::error!(err.msg = %e, err.details = ?e, "Internal server error");
-    // We don't want to leak internal implementation details to the client
-    // via the error response, so we just return an opaque internal server.
-    StatusCode::INTERNAL_SERVER_ERROR
 }
 
 /// Initializes tracing.


### PR DESCRIPTION
- Have db::Error::DbError wrap a sqlx::error instead of anyhow::Error, and clarify the semantics of db::Error::NoRecordFound
- Add error module in web crate, with Error type that implements IntoResponse. Use it in generated tasks controller

Fixes #110 