### PR TITLE
Enable error debug output by default in CLI binaries

### DIFF
--- a/blueprint/cli/src/bin/db.rs
+++ b/blueprint/cli/src/bin/db.rs
@@ -31,8 +31,8 @@ struct Cli {
     #[arg(long, global = true, help = "Disable colored output.")]
     no_color: bool,
 
-    #[arg(long, global = true, help = "Enable debug output.")]
-    debug: bool,
+    #[arg(long, global = true, help = "Disable debug output.")]
+    quiet: bool,
 }
 
 #[derive(Subcommand)]
@@ -55,7 +55,7 @@ async fn cli() {
 
     let mut stdout = std::io::stdout();
     let mut stderr = std::io::stderr();
-    let mut ui = UI::new(&mut stdout, &mut stderr, !cli.no_color, cli.debug);
+    let mut ui = UI::new(&mut stdout, &mut stderr, !cli.no_color, !cli.quiet);
 
     let config: Result<Config, anyhow::Error> = load_config(&cli.env);
     match config {

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -33,8 +33,8 @@ struct Cli {
     #[arg(long, global = true, help = "Disable colored output.")]
     no_color: bool,
 
-    #[arg(long, global = true, help = "Enable debug output.")]
-    debug: bool,
+    #[arg(long, global = true, help = "Disable debug output.")]
+    quiet: bool,
 }
 
 #[derive(Subcommand)]
@@ -88,7 +88,7 @@ pub async fn cli() {
     let cli = Cli::parse();
     let mut stdout = std::io::stdout();
     let mut stderr = std::io::stderr();
-    let mut ui = UI::new(&mut stdout, &mut stderr, !cli.no_color, cli.debug);
+    let mut ui = UI::new(&mut stdout, &mut stderr, !cli.no_color, !cli.quiet);
 
     match cli.command {
         Commands::Middleware { name } => {

--- a/blueprint/web/src/routes.rs.liquid
+++ b/blueprint/web/src/routes.rs.liquid
@@ -3,10 +3,7 @@ use crate::state::AppState;
 use axum::Router;
 
 {% elsif template_type == "full" -%}
-use crate::controllers::tasks::{
-    create as create_task, create_batch as create_tasks, delete as delete_task,
-    read_all as get_tasks, read_one as get_task, update as update_task,
-};
+use crate::controllers::tasks;
 use crate::middlewares::auth::auth;
 use crate::state::AppState;
 use axum::{
@@ -15,7 +12,7 @@ use axum::{
     Router,
 };
 {%- elsif template_type == "minimal" %}
-use crate::controllers::greeting::hello;
+use crate::controllers::greeting;
 use crate::state::AppState;
 use axum::{routing::get, Router};
 {%- endif %}
@@ -28,17 +25,17 @@ pub fn init_routes(app_state: AppState) -> Router {
     Router::new().with_state(app_state)
 {% elsif template_type == "full" -%}
     Router::new()
-        .route("/tasks", post(create_task))
-        .route("/tasks", put(create_tasks))
-        .route("/tasks/:id", delete(delete_task))
-        .route("/tasks/:id", put(update_task))
+        .route("/tasks", post(tasks::create))
+        .route("/tasks", put(tasks::create_batch))
+        .route("/tasks/:id", delete(tasks::delete))
+        .route("/tasks/:id", put(tasks::update))
         .route_layer(middleware::from_fn_with_state(app_state.clone(), auth))
-        .route("/tasks", get(get_tasks))
-        .route("/tasks/:id", get(get_task))
+        .route("/tasks", get(tasks::read_all))
+        .route("/tasks/:id", get(tasks::read_one))
         .with_state(app_state)
 {%- elsif template_type == "minimal" %}
     Router::new()
-        .route("/greet", get(hello))
+        .route("/greet", get(greeting::hello))
         .with_state(app_state)
 {%- endif %}
 }


### PR DESCRIPTION
If something goes wrong when running a command, it's always reasonable to assume the user wants error details.