### PR TITLE
Don't generate irrelevant blueprints for minimal apps

### DIFF
--- a/blueprint/cargo-generate.toml
+++ b/blueprint/cargo-generate.toml
@@ -12,6 +12,8 @@ ignore = [
     "db",
     "docker-compose.yml",
     "cli/src/bin/db.rs",
+    "cli/blueprints/entity",
+    "cli/blueprints/entity-test-helper",
     "web/src/middlewares/auth.rs",
     "web/src/controllers/tasks.rs",
     "web/tests/api/tasks_test.rs",


### PR DESCRIPTION
Minimal projects should not include the file blueprints for entities and entity test helpers. Since all files end up in the user's project, that would be confusing