### PR TITLE
Propagate all args to cli binaries in cargo alias config

### DIFF
--- a/blueprint/.cargo/config.toml
+++ b/blueprint/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 {% if template_type != "minimal" -%}
-db = ["run", "--package", "{{project-name}}-cli", "--bin", "db"]
+db = ["run", "--package", "{{project-name}}-cli", "--bin", "db", "--"]
 {% endif -%}
-generate = ["run", "--package", "{{project-name}}-cli", "--bin", "generate"]
+generate = ["run", "--package", "{{project-name}}-cli", "--bin", "generate", "--"]


### PR DESCRIPTION
Makes `cargo generate --help` just work