### PR TITLE
Remove prefix for migrations generated by the generate app

### DIFF
--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -253,7 +253,7 @@ async fn generate_controller_test(name: String) -> Result<String, anyhow::Error>
 {% if template_type != "minimal" -%}
 async fn generate_migration(name: String) -> Result<String, anyhow::Error> {
     let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
-    let file_name = format!("V{}__{}.sql", timestamp.as_secs(), name);
+    let file_name = format!("{}__{}.sql", timestamp.as_secs(), name);
     let path = format!("./db/migrations/{}", file_name);
     create_project_file(&path, "".as_bytes())?;
 


### PR DESCRIPTION
Fixes errros such as:

```
ℹ️  Migrating development database…
❌ Could not migrate database!
Failed to create migrator!

Caused by:
    0: while resolving migrations: error parsing migration filename "V1732527955__test.sql"; expected integer version prefix (e.g. `01_foo.sql`)
    1: error parsing migration filename "V1732527955__test.sql"; expected integer version prefix (e.g. `01_foo.sql`)
```

For migrations generated with the `cargo generate migration` command