### PR TITLE
fix exit codes of binaries

### DIFF
--- a/blueprint/cli/blueprints/controller/crud/test.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/crud/test.rs.liquid.liquid
@@ -1,4 +1,3 @@
-use {{crate_name}}_web::test_helpers::{BodyExt, DbTestContext, RouterExt};
 use axum::{
     body::Body,
     http::{self, Method},
@@ -8,6 +7,7 @@ use googletest::prelude::*;
 use hyper::StatusCode;
 use {{db_crate_name}}::{entities, transaction, Error};
 use {{macros_crate_name}}::db_test;
+use {{web_crate_name}}::test_helpers::{BodyExt, DbTestContext, RouterExt};
 use serde_json::json;
 use std::collections::HashMap;
 use uuid::Uuid;

--- a/blueprint/cli/blueprints/controller/minimal/test.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/minimal/test.rs.liquid.liquid
@@ -1,12 +1,12 @@
-{%- if has_db -%}
-use {{crate_name}}_web::test_helpers::{BodyExt, DbTestContext, RouterExt};
-{% else %}
-use {{crate_name}}_web::test_helpers::{BodyExt, DbTestContext, RouterExt};
-{%- endif -%}
 use axum::{body::Body, http::Method};
 use googletest::prelude::*;
 use hyper::StatusCode;
 use {{macros_crate_name}}::test;
+{% if has_db -%}
+use {{web_crate_name}}::test_helpers::{BodyExt, DbTestContext, RouterExt};
+{% else %}
+use {{web_crate_name}}::test_helpers::{BodyExt, TestContext, RouterExt};
+{%- endif -%}
 use std::collections::HashMap;
 
 #[db_test]

--- a/blueprint/cli/src/bin/db.rs
+++ b/blueprint/cli/src/bin/db.rs
@@ -93,8 +93,9 @@ async fn cli(mut ui: &mut UI<'_>, cli: Cli) -> Result<(), anyhow::Error> {
                     ui.indent();
                     let migrations = migrate(&mut ui, &config.database)
                         .await
-                        .context("Could not migrate database!")?;
+                        .context("Could not migrate database!");
                     ui.outdent();
+                    let migrations = migrations?;
                     ui.success(&format!("{} migrations applied.", migrations));
                     Ok(())
                 }
@@ -129,12 +130,7 @@ async fn cli(mut ui: &mut UI<'_>, cli: Cli) -> Result<(), anyhow::Error> {
                 
                         cmd.args(["sqlx", "prepare", "--", "--all-targets", "--all-features"]);
                 
-                        let cmd_cwd = match db_package_root() {
-                            Ok(cwd) => cwd,
-                            Err(e) => {
-                                return Err(e.context("Error finding the root of the db package!"));
-                            }
-                        };
+                        let cmd_cwd = db_package_root().context("Error finding the root of the db package!")?;
                         cmd.current_dir(cmd_cwd);
                 
                         cmd.env("DATABASE_URL", &config.database.url);

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -11,6 +11,7 @@ use liquid::Template;
 use {{crate_name}}_cli::util::ui::UI;
 use std::fs::{self, File, OpenOptions};
 use std::io::prelude::*;
+use std::process::ExitCode;
 {% if template_type != "minimal" -%}
 use std::time::SystemTime;
 {% endif -%}
@@ -19,8 +20,11 @@ static BLUEPRINTS_DIR: include_dir::Dir =
     include_dir::include_dir!("$CARGO_MANIFEST_DIR/blueprints");
 
 #[tokio::main]
-async fn main() {
-    cli().await;
+async fn main() -> ExitCode {
+    match cli().await {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(_) => ExitCode::FAILURE,
+    }
 }
 
 #[derive(Parser)]
@@ -84,7 +88,7 @@ enum Commands {
 }
 
 #[allow(missing_docs)]
-pub async fn cli() {
+async fn cli() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();
     let mut stdout = std::io::stdout();
     let mut stderr = std::io::stderr();
@@ -94,8 +98,14 @@ pub async fn cli() {
         Commands::Middleware { name } => {
             ui.info("Generating middleware…");
             match generate_middleware(name).await {
-                Ok(file_name) => ui.success(&format!("Generated middleware {}.", &file_name)),
-                Err(e) => ui.error("Could not generate middleware!", e),
+                Ok(file_name) => {
+                    ui.success(&format!("Generated middleware {}.", &file_name));
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.error("Could not generate middleware!", &e);
+                    Err(e)
+                }
             }
         }
         Commands::Controller { name } => {
@@ -107,48 +117,74 @@ pub async fn cli() {
                         "Do not forget to route the controller's actions in ./web/src/routes.rs!",
                     );
                 }
-                Err(e) => ui.error("Could not generate controller!", e),
+                Err(e) => ui.error("Could not generate controller!", &e),
             }
             ui.info("Generating test for controller…");
             match generate_controller_test(name).await {
                 Ok(file_name) => {
-                    ui.success(&format!("Generated test for controller {}.", &file_name))
+                    ui.success(&format!("Generated test for controller {}.", &file_name));
+                    Ok(())
                 }
-                Err(e) => ui.error("Could not generate test for controller!", e),
+                Err(e) => {
+                    ui.error("Could not generate test for controller!", &e);
+                    Err(e)
+                }
             }
         }
         Commands::ControllerTest { name } => {
             ui.info("Generating test for controller…");
             match generate_controller_test(name).await {
                 Ok(file_name) => {
-                    ui.success(&format!("Generated test for controller {}.", &file_name))
+                    ui.success(&format!("Generated test for controller {}.", &file_name));
+                    Ok(())
                 }
-                Err(e) => ui.error("Could not generate test for controller!", e),
+                Err(e) => {
+                    ui.error("Could not generate test for controller!", &e);
+                    Err(e)
+                }
             }
         }
         {% if template_type != "minimal" -%}
         Commands::Migration { name } => {
             ui.info("Generating migration…");
             match generate_migration(name).await {
-                Ok(file_name) => ui.success(&format!("Generated migration {}.", &file_name)),
-                Err(e) => ui.error("Could not generate migration!", e),
+                Ok(file_name) => {
+                    ui.success(&format!("Generated migration {}.", &file_name));
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.error("Could not generate migration!", &e);
+                    Err(e)
+                }
             }
         }
         Commands::Entity { name } => {
             ui.info("Generating entity…");
             match generate_entity(name).await {
-                Ok(struct_name) => ui.success(&format!("Generated entity {}.", &struct_name)),
-                Err(e) => ui.error("Could not generate entity!", e),
+                Ok(struct_name) => {
+                    ui.success(&format!("Generated entity {}.", &struct_name));
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.error("Could not generate entity!", &e);
+                    Err(e)
+                }
             }
         }
         Commands::EntityTestHelper { name } => {
             ui.info("Generating entity test helper…");
             match generate_entity_test_helper(name).await {
-                Ok(struct_name) => ui.success(&format!(
-                    "Generated test helper for entity {}.",
-                    &struct_name
-                )),
-                Err(e) => ui.error("Could not generate entity test helper!", e),
+                Ok(struct_name) => {
+                    ui.success(&format!(
+                        "Generated test helper for entity {}.",
+                        &struct_name
+                    ));
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.error("Could not generate entity test helper!", &e);
+                    Err(e)
+                }
             }
         }
         Commands::CrudController { name } => {
@@ -160,25 +196,37 @@ pub async fn cli() {
                         "Do not forget to route the controller's actions in ./web/src/routes.rs!",
                     );
                 }
-                Err(e) => ui.error("Could not generate CRUD controller!", e),
+                Err(e) => ui.error("Could not generate CRUD controller!", &e),
             }
             ui.info("Generating test for CRUD controller…");
             match generate_crud_controller_test(name).await {
-                Ok(file_name) => ui.success(&format!(
-                    "Generated test for CRUD controller {}.",
-                    &file_name
-                )),
-                Err(e) => ui.error("Could not generate test for CRUD controller!", e),
+                Ok(file_name) => {
+                    ui.success(&format!(
+                        "Generated test for CRUD controller {}.",
+                        &file_name
+                    ));
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.error("Could not generate test for CRUD controller!", &e);
+                    Err(e)
+                }
             }
         }
         Commands::CrudControllerTest { name } => {
             ui.info("Generating test for CRUD controller…");
             match generate_crud_controller_test(name).await {
-                Ok(file_name) => ui.success(&format!(
-                    "Generated test for CRUD controller {}.",
-                    &file_name
-                )),
-                Err(e) => ui.error("Could not generate test for CRUD controller!", e),
+                Ok(file_name) => {
+                    ui.success(&format!(
+                        "Generated test for CRUD controller {}.",
+                        &file_name
+                    ));
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.error("Could not generate test for CRUD controller!", &e);
+                    Err(e)
+                }
             }
         }
         {% endif -%}

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -279,12 +279,15 @@ async fn generate_controller_test(name: String) -> Result<String, anyhow::Error>
     let name = to_snake_case(&name).to_lowercase();
     let macros_crate_name = get_member_package_name("macros")?;
     let macros_crate_name = to_snake_case(&macros_crate_name);
+    let web_crate_name = get_member_package_name("web")?;
+    let web_crate_name = to_snake_case(&web_crate_name);
     let has_db = has_db();
 
     let template = get_liquid_template("controller/minimal/test.rs")?;
     let variables = liquid::object!({
         "name": name,
         "macros_crate_name": macros_crate_name,
+        "web_crate_name": web_crate_name,
         "has_db": has_db,
     });
     let output = template
@@ -403,6 +406,8 @@ async fn generate_crud_controller_test(name: String) -> Result<String, anyhow::E
     let db_crate_name = to_snake_case(&db_crate_name);
     let macros_crate_name = get_member_package_name("macros")?;
     let macros_crate_name = to_snake_case(&macros_crate_name);
+    let web_crate_name = get_member_package_name("web")?;
+    let web_crate_name = to_snake_case(&web_crate_name);
 
     let template = get_liquid_template("controller/crud/test.rs")?;
     let variables = liquid::object!({
@@ -410,7 +415,8 @@ async fn generate_crud_controller_test(name: String) -> Result<String, anyhow::E
         "entity_singular_name": name_singular,
         "entity_plural_name": name_plural,
         "db_crate_name": db_crate_name,
-        "macros_crate_name": macros_crate_name
+        "macros_crate_name": macros_crate_name,
+        "web_crate_name": web_crate_name,
     });
     let output = template
         .render(&variables)

--- a/blueprint/web/src/main.rs
+++ b/blueprint/web/src/main.rs
@@ -1,15 +1,20 @@
 #![allow(missing_docs)]
 use {{crate_name}}_web::{init_tracing, run};
+use std::process::ExitCode;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
     init_tracing();
 
-    if let Err(e) = run().await {
-        tracing::error!(
-            error.msg = %e,
-            error.error_chain = ?e,
-            "Shutting down due to error"
-        )
+    match run().await {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(e) => {
+            tracing::error!(
+                error.msg = %e,
+                error.error_chain = ?e,
+                "Shutting down due to error"
+            );
+            ExitCode::FAILURE
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ async fn main() {
         }
         Err(e) => {
             ui.outdent();
-            ui.error("Could not generate project!", e);
+            ui.error("Could not generate project!", &e);
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -91,7 +91,7 @@ impl<'a> UI<'a> {
     /// Prints an error message.
     ///
     /// If color output is enabled (see [`UI::new`]), the message will be formatted. If debug output is enabled (see [`UI::new`]), the error's stack trace will be printed as well.
-    pub fn error(&mut self, msg: &str, e: anyhow::Error) {
+    pub fn error(&mut self, msg: &str, e: &anyhow::Error) {
         let indentation = self.indentation();
         self.errout(&format!("{}{}{}", indentation, self.error_prefix, msg));
         if self.debug {
@@ -169,7 +169,7 @@ mod tests {
         ui.log("a general message");
         ui.info("an info message");
         ui.success("a success message ✓");
-        ui.error("an error message :(", anyhow!("oh no…"));
+        ui.error("an error message :(", &anyhow!("oh no…"));
 
         let output = read_buffer(stdout);
         let error_output = read_buffer(stderr);
@@ -192,7 +192,7 @@ mod tests {
         ui.log("a general message");
         ui.info("an info message");
         ui.success("a success message ✓");
-        ui.error("an error message :(", anyhow!("oh no…"));
+        ui.error("an error message :(", &anyhow!("oh no…"));
 
         let output = read_buffer(stdout);
         let error_output = read_buffer(stderr);


### PR DESCRIPTION
This fixes the exit codes of the project binaries that currently swallow any errors (they log the errors but always return a successful exit code. That's not critical when working with the binaries in development but leads to bugs like #169 going unnoticed in CI…

The code is quite repetitive now and could use some cleanup eventually.

This also fixes 2 actual errors in the generators which fix CI (which now correctly fails because of these errors).

closes #169