### PR TITLE
Make #[ignore] and other attrs on tests possible

### DIFF
--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -22,6 +22,7 @@ use syn::{parse_macro_input, ItemFn};
 #[proc_macro_attribute]
 pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
+    let test_attrs = input.attrs;
     let test_name = input.sig.ident.clone();
     let test_arguments = input.sig.inputs;
     let test_block = input.block;
@@ -36,6 +37,7 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
 
     let output = quote!(
         #[::tokio::test]
+        #(#test_attrs)*
         async fn #test_name() {
             #setup
             async fn #inner_test_name(#test_arguments) #test_block
@@ -82,6 +84,7 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn db_test(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
+    let test_attrs = input.attrs;
     let test_name = input.sig.ident.clone();
     let test_arguments = input.sig.inputs;
     let test_block = input.block;
@@ -100,6 +103,7 @@ pub fn db_test(_: TokenStream, item: TokenStream) -> TokenStream {
 
     let output = quote!(
         #[::tokio::test]
+        #(#test_attrs)*
         async fn #test_name() {
             #setup
             async fn #inner_test_name(#test_arguments) #test_block


### PR DESCRIPTION
### Description

Hi there and thank you guys for this framework!

I needed to ignore a couple of tests and so had to patch the `macros` crate in my project.
Bringing it upstream.

We can now do the usual:
```rust
#[ignore = "no good reason"]
#[db_test]
async fn test_create_success(context: &DbTestContext) {}

#[ignore = "no good reason either"]
#[test]
async fn test_create_success(context: &DbTestContext) {}
```

### Testing

To quickly test this, hit this from the project's root:
```bash
cargo run -- test_project --full
cd test_project
docker compose up -d
cargo db migrate
cargo db migrate -e test
cargo db prepare
cargo t
```
Then go ahead and ignore one of the tests in `test_project/web/tests/api/tasks_test.rs` and rerun the `cargo t` command staying in the `test_project` directory.The output  should resemble:

![image](https://github.com/user-attachments/assets/97d97881-8237-4ae3-b0d4-51e3e1c278a2)

### Caveats

This functionality might not have been added _for a reason_, but I have not found it documented.
And if there is a reason why we should be ignoring any other attributes, then we should probably allow users to ignore a test (with an optional reason message) via the macro itself (e.g. `#[db_test(ignore)`), but that seems to be less predictable for end-users and implies for maintenance burden, while the `macro` crate is supposed to be a relatively lightweight helper rather than a feature-rich library.

