### PR TITLE
do nor tun Gravtiy on forks

### DIFF
--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Run Gravity
     runs-on: ubuntu-latest
+    if: github.repository == 'mainmatter/gerust'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Since builds on forks don't receive secrets, the Gravity job can never work, see e.g. #190 