### PR TITLE
fix Gravity on PRs

### DIFF
--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Run Gravity
     runs-on: ubuntu-latest
-    if: github.repository == 'mainmatter/gerust'
+    if: ${{ github.repository_owner == 'mainmatter' }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
…by preventing it from running at all. Gravity cannot run in PRs since those don't have access to secrets (see e.g. #224).