### PR TITLE
Allow field names to be specified when generating an entity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,7 +472,7 @@ jobs:
     - name: generate-entity
       run: |
         cd my-app
-        cargo generate entity Person
+        cargo generate entity Person first_name:String last_name:String age:i16
 
     - name: generate-entity-test-helper
       run: |

--- a/blueprint/cli/Cargo.toml.liquid
+++ b/blueprint/cli/Cargo.toml.liquid
@@ -26,6 +26,7 @@ include_dir = "0.7"
 liquid = "~0.26"
 {{project-name}}-config = { path = "../config" }
 {% unless template_type == "minimal" -%}
+regex = "1.11"
 sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono" ] }
 url = "2.5"
 {%- endunless %}

--- a/blueprint/cli/blueprints/entity/file.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/entity/file.rs.liquid.liquid
@@ -1,5 +1,5 @@
 #[cfg(feature = "test-helpers")]
-use fake::{faker::name::en::*, Dummy};
+use fake::{faker::lorem::en::*, Dummy};
 use serde::Deserialize;
 use serde::Serialize;
 use sqlx::Postgres;
@@ -8,25 +8,26 @@ use validator::Validate;
 
 #[derive(Serialize, Debug, Deserialize)]
 pub struct {{entity_struct_name}} {
-    // these are examples only
     pub id: Uuid,
-    pub name: String,
+    {%- for field in fields %}
+    pub {{ field.name }}: {{ field.type }},
+    {%- endfor %}
 }
 
 #[derive(Deserialize, Validate, Clone)]
 #[cfg_attr(feature = "test-helpers", derive(Serialize, Dummy))]
 pub struct {{entity_struct_name}}Changeset {
-    // these are examples only
-    #[cfg_attr(feature = "test-helpers", dummy(faker = "Name()"))]
-    #[validate(length(min = 1))]
-    pub name: String,
+    {%- for field in fields %}
+    //#[cfg_attr(feature = "test-helpers", dummy(faker = "…()"))]
+    //#[validate(…))]
+    pub {{ field.name }}: {{ field.type }},
+    {%- endfor %}
 }
 
 pub async fn load_all(
     executor: impl sqlx::Executor<'_, Database = Postgres>,
 ) -> Result<Vec<{{entity_struct_name}}>, crate::Error> {
-    todo!("Adapt the SQL query as necessary!");
-    let {{entity_plural_name}} = sqlx::query_as!({{entity_struct_name}}, "SELECT id, name FROM {{entity_plural_name}}")
+    let {{entity_plural_name}} = sqlx::query_as!({{entity_struct_name}}, "SELECT id, {{ fields | map: "name" | join: ", " }} FROM {{entity_plural_name}}")
         .fetch_all(executor)
         .await?;
     Ok({{entity_plural_name}})
@@ -36,10 +37,9 @@ pub async fn load(
     id: Uuid,
     executor: impl sqlx::Executor<'_, Database = Postgres>,
 ) -> Result<{{entity_struct_name}}, crate::Error> {
-    todo!("Adapt the SQL query as necessary!");
     match sqlx::query_as!(
         {{entity_struct_name}},
-        "SELECT id, description FROM {{entity_plural_name}} WHERE id = $1",
+        "SELECT id, {{ fields | map: "name" | join: ", " }} FROM {{entity_plural_name}} WHERE id = $1",
         id
     )
     .fetch_optional(executor)
@@ -57,10 +57,12 @@ pub async fn create(
 ) -> Result<{{entity_struct_name}}, crate::Error> {
     {{entity_singular_name}}.validate()?;
 
-    todo!("Adapt the SQL query and bound parameters as necessary!");
     let record = sqlx::query!(
-        "INSERT INTO {{entity_plural_name}} (name) VALUES ($1) RETURNING id",
-        {{entity_singular_name}}.name
+        "INSERT INTO {{entity_plural_name}} ({{ fields | map: "name" | join: ", " }}) VALUES ({%- for field in fields -%}${{ forloop.index }}{%- unless forloop.last -%}, {% endunless -%}{%- endfor -%}) RETURNING id",
+        {%- for field in fields %}
+        {{entity_singular_name}}.{{ field.name }},
+        {%- endfor %}
+
     )
     .fetch_one(executor)
     .await
@@ -68,7 +70,9 @@ pub async fn create(
 
     Ok({{entity_struct_name}} {
         id: record.id,
-        name: {{entity_singular_name}}.name,
+        {%- for field in fields %}
+        {{ field.name }}: {{entity_singular_name}}.{{ field.name }},
+        {%- endfor %}
     })
 }
 
@@ -79,10 +83,11 @@ pub async fn update(
 ) -> Result<{{entity_struct_name}}, crate::Error> {
     {{entity_singular_name}}.validate()?;
 
-    todo!("Adapt the SQL query and bound parameters as necessary!");
     match sqlx::query!(
-        "UPDATE {{entity_plural_name}} SET name = $1 WHERE id = $2 RETURNING id, name",
-        {{entity_singular_name}}.name,
+        "UPDATE {{entity_plural_name}} SET {% for field in fields -%}{{ field.name }} = ${{ forloop.index }}{%- unless forloop.last -%}, {% endunless -%}{%- endfor %} WHERE id = ${{ fields | size | plus: 1 }} RETURNING id",
+        {%- for field in fields %}
+        {{entity_singular_name}}.{{ field.name }},
+        {%- endfor %}
         id
     )
     .fetch_optional(executor)
@@ -91,7 +96,9 @@ pub async fn update(
     {
         Some(record) => Ok({{entity_struct_name}} {
             id: record.id,
-            name: record.name,
+            {%- for field in fields %}
+            {{ field.name }}: {{entity_singular_name}}.{{ field.name }},
+            {%- endfor %}
         }),
         None => Err(crate::Error::NoRecordFound),
     }
@@ -101,7 +108,6 @@ pub async fn delete(
     id: Uuid,
     executor: impl sqlx::Executor<'_, Database = Postgres>,
 ) -> Result<(), crate::Error> {
-    todo!("Adapt the SQL query as necessary!");
     match sqlx::query!("DELETE FROM {{entity_plural_name}} WHERE id = $1 RETURNING id", id)
         .fetch_optional(executor)
         .await

--- a/blueprint/cli/blueprints/entity/file.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/entity/file.rs.liquid.liquid
@@ -62,7 +62,6 @@ pub async fn create(
         {%- for field in fields %}
         {{entity_singular_name}}.{{ field.name }},
         {%- endfor %}
-
     )
     .fetch_one(executor)
     .await

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -9,6 +9,10 @@ use cruet::{
 use guppy::{graph::PackageGraph, MetadataCommand};
 use liquid::Template;
 use {{crate_name}}_cli::util::ui::UI;
+{% if template_type != "minimal" -%}
+use regex::Regex;
+use std::collections::HashMap;
+{% endif -%}
 use std::fs::{self, File, OpenOptions};
 use std::io::prelude::*;
 use std::process::ExitCode;
@@ -455,6 +459,7 @@ fn get_member_package_name(path: &str) -> Result<String, anyhow::Error> {
     Err(anyhow!("Could not find workspace member at path: {}", path))
 }
 
+{% if template_type != "minimal" -%}
 fn validate_fields(fields: &Vec<String>) -> Result<Vec<HashMap<String, String>>, anyhow::Error> {
     let re =
         Regex::new(r"^([a-zA-Z][a-zA-Z0-9_]+)\:(bool|Bool|i8|i16|i32|i64|f32|f64|String|string)$")
@@ -484,3 +489,4 @@ fn validate_fields(fields: &Vec<String>) -> Result<Vec<HashMap<String, String>>,
 
     Ok(mapped_fields)
 }
+{% endif -%}

--- a/site/docs/tutorial-standard/auth-middleware.md
+++ b/site/docs/tutorial-standard/auth-middleware.md
@@ -17,7 +17,7 @@ The middleware introduced in this chapter is not actually a proper way to implem
 First, we need to introduce the concept of a user as such. We can do that by generating a `User` entity the same way we created the `Note` entity [in the first step](./the-entity):
 
 ```
-» cargo generate entity user
+» cargo generate entity user name:string
 ```
 
 In this case, we don't keep most of the generated standard blueprint code since we want to treat users very differently than notes: Users cannot be created as part of the app's normal execution flow so we don't need a `UserChangeset` or the `create`, `update`, or `delete` functions. Also, users can only be loaded by their secret token (which is going to be included in incoming requests to identify the users) but not by their ID and we also don't need to be able to load all users at once. Plus, the token should not be leaked obviously and does never actually need to be read during the program's execution. Thus, the `User` entity and its related functionality can be shortened to this:
@@ -51,7 +51,7 @@ Note that the `User` entity needs to implement the `Clone` trait so that we can 
 
 :::
 
-The `User` entity has an `id` and `name` only – the `token` is not exposed as a property at all so there's no risk of leaking it by e.g. responding with a `User` entity that's serialized to JSON. The only way to load a user from the database is via the user's secret token and the `load_with_token` function.
+The `User` entity has an `id` and `name` only – we did not include the token in the field list when generating ent entity because we don't want it to be exposed as a property at all so there's no risk of leaking it by e.g. responding with a `User` entity that's serialized to JSON. The only way to load a user from the database is via the user's secret token and the `load_with_token` function.
 
 Let's generate the corresponding migration next:
 

--- a/site/docs/tutorial-standard/reading-endpoints.md
+++ b/site/docs/tutorial-standard/reading-endpoints.md
@@ -129,7 +129,7 @@ date: Wed, 22 Jan 2025 14:01:54 GMT
 
 ## Testing
 
-When the `notes` controller was created, Gerust automatically created a test for it in `web/tests/api/notes_test.rs`. It comes with test cases for all of the scenarios we'll want to cover for a <abbr>CRUD</abbr> controller. Since we only care about the `read_all` and `read_one` endpoints for now, we can uncomment the auto-generated code for the respective test cases, replace the example `description` property with the `text` property that we're using, and remove the `#[ignore]`s:
+When the `notes` controller was created, Gerust automatically created a test for it in `web/tests/api/notes_test.rs`. It comes with test cases for all of the scenarios we'll want to cover for a <abbr>CRUD</abbr> controller. Since we only care about the `read_all` and `read_one` endpoints for now, we can uncomment the auto-generated code for the respective test cases, replace the example `name` property with the `text` property that we're using, and remove the `#[ignore]`s:
 
 ```rust
 use axum::{


### PR DESCRIPTION
…so not everyone needs to always change the field names and adopt all SQL quieries

```
cargo generate entity Person first_name:String last_name:String age:i16
```