### PR TITLE
feat(db): allow specifying up/down migrations

### DIFF
--- a/blueprint/cli/src/bin/db.rs
+++ b/blueprint/cli/src/bin/db.rs
@@ -215,6 +215,11 @@ async fn migrate(ui: &mut UI<'_>, config: &DatabaseConfig) -> Result<i32, anyhow
 
     let mut applied = 0;
     for migration in migrator.iter() {
+        if migration.migration_type.is_down_migration() {
+            // Avoid accidentally running a "down" migration.
+            continue;
+        }
+
         if !applied_migrations.contains_key(&migration.version) {
             connection
                 .apply(migration)


### PR DESCRIPTION
Gerust currently doesn't support `up` or `down` suffixes when generating migrations.

This PR, while not providing a `Revert`/`Rollback` command, allows users to generate a migration such as `db/migrations/1748862562__hello.up.sql` and makes it a default.
It'll allow users to easily make use of `sqlx-cli` however until we provide such command.

- Adds ability to generate migrations with `up`/`down` suffixes
- Changes `cargo db migrate` command to not accidentally run a `down` migration.
- Makes `up`/`down` migrations to be generated by default.

`cargo generate migration hello`
> ℹ️  Generating migration…
✅ Generated migration ./db/migrations/1748862562__hello.up.sql.
✅ Generated migration ./db/migrations/1748862562__hello.down.sql.

`cargo generate migration hello --simple`
> ℹ️  Generating migration…
✅ Generated migration ./db/migrations/1748862566__hello.sql.

`cargo db migrate`
Notice how it correctly runs only the `./db/migrations/1748862562__hello.up.sql` and `./db/migrations/1748862566__hello.sql` files and not a `down` one.

> ℹ️  Migrating development database…
     Applied migration 1748862562.
     Applied migration 1748862566.
✅ 2 migrations applied.


*Not a part of this PR*

- [ ] Add a `revert`/`rollback` command - a reverse of `cargo db migrate`
