### PR TITLE
don't just override project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ Commands:
 
 Options:
       --no-color  Disable colored output.
-      --debug     Enable debug output.
+      --quiet     Disable debug output.
+      --override  Override existing files.
   -h, --help      Print help
   -V, --version   Print version
 ```

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -412,11 +412,15 @@ fn get_liquid_template(path: &str) -> Result<Template, anyhow::Error> {
 }
 
 fn create_project_file(path: &str, contents: &[u8]) -> Result<(), anyhow::Error> {
-    let mut file = File::create(path).context(format!(r#"Could not create file "{}""#, path))?;
-    file.write_all(contents)
-        .context(format!(r#"Could not write file "{}""#, path))?;
-
-    Ok(())
+    if Path::new(path).exists() {
+        Err(anyhow!("File {} already exists!", path))
+    } else {
+        let mut file = File::create(path).context(format!(r#"Could not create file "{}""#, path))?;
+        file.write_all(contents)
+            .context(format!(r#"Could not write file "{}""#, path))?;
+        
+        Ok(())
+    }
 }
 
 fn append_to_project_file(path: &str, contents: &str) -> Result<(), anyhow::Error> {

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 {% endif -%}
 use std::fs::{self, File, OpenOptions};
 use std::io::prelude::*;
+use std::path::Path;
 use std::process::ExitCode;
 {% if template_type != "minimal" -%}
 use std::time::SystemTime;
@@ -211,7 +212,7 @@ async fn generate_middleware(name: String, r#override: bool) -> Result<String, a
         .context("Failed to render Liquid template")?;
 
     let file_path = format!("./web/src/middlewares/{}.rs", name);
-    create_project_file(&file_path, output.as_bytes())?;
+    create_project_file(&file_path, output.as_bytes(), r#override)?;
     append_to_project_file(
         "./web/src/middlewares/mod.rs",
         &format!("pub mod {};", name),
@@ -358,11 +359,10 @@ async fn generate_crud_controller(name: String, r#override: bool) -> Result<Stri
         .context("Failed to render Liquid template")?;
 
     let file_path = format!("./web/src/controllers/{}.rs", name);
-    create_project_file(&file_path, output.as_bytes())?;
+    create_project_file(&file_path, output.as_bytes(), r#override)?;
     append_to_project_file(
         "./web/src/controllers/mod.rs",
         &format!("pub mod {};", name),
-        r#override,
     )?;
 
     Ok(file_path)

--- a/site/docs/architecture/the-cli-crate.md
+++ b/site/docs/architecture/the-cli-crate.md
@@ -32,7 +32,8 @@ Commands:
 
 Options:
       --no-color  Disable colored output.
-      --debug     Enable debug output.
+      --quiet     Disable debug output.
+      --override  Override existing files.
   -h, --help      Print help
   -V, --version   Print version
 ```


### PR DESCRIPTION
Currently, `cargo generate` will just happily override any existing files which of course might override changes the developer has made already. This fixes changes the behavior so that if the generator finds that a file already exists, it fails with an error.