### PR TITLE
docs: Better describe entity generation in README and CLI

### DIFF
--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -85,7 +85,7 @@ enum Commands {
         #[arg(long, help = "Generate a simple (non-reversible) migration as a single .sql file.")]
         simple: bool,
     },
-    #[command(about = "Generate an entity. The created entity will have a `id` field of type `Uuid`. It is recommended to specify all fields to avoid having to fill them in the generated file manually.")]
+    #[command(about = "Generate an entity. The created entity will have a `id` field of type `Uuid`. You can also specify additional fields to avoid having to fill them in the generated structs and functions manually.")]
     Entity {
         #[arg(help = "The name of the entity.")]
         name: String,

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -85,7 +85,7 @@ enum Commands {
         #[arg(long, help = "Generate a simple (non-reversible) migration as a single .sql file.")]
         simple: bool,
     },
-    #[command(about = "Generate an entity")]
+    #[command(about = "Generate an entity. The created entity will have a `id` field of type `Uuid`. It is recommended to specify all fields to avoid having to fill them in the generated file manually.")]
     Entity {
         #[arg(help = "The name of the entity.")]
         name: String,

--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -85,7 +85,7 @@ enum Commands {
         #[arg(long, help = "Generate a simple (non-reversible) migration as a single .sql file.")]
         simple: bool,
     },
-    #[command(about = "Generate an entity. The created entity will have a `id` field of type `Uuid`. You can also specify additional fields to avoid having to fill them in the generated structs and functions manually.")]
+    #[command(about = "Generate an entity. The created entity will have a `id` field of type `Uuid`.")]
     Entity {
         #[arg(help = "The name of the entity.")]
         name: String,

--- a/blueprint/db/README.md
+++ b/blueprint/db/README.md
@@ -16,7 +16,9 @@ pub struct User {
 }
 ```
 
-New entities are created with `cargo generate`. The created entity will have an `id` field of type `Uuid`. You can also specify additional fields. The command below generates the `User` entity seen above:
+New entities are created with `cargo generate`. The created entity will have an `id` field of type `Uuid`.
+You can also specify additional fields to avoid having to fill them in the generated structs and functions manually.
+The command below generates the `User` entity seen above:
 
 ```sh
 cargo generate entity user name:String

--- a/blueprint/db/README.md
+++ b/blueprint/db/README.md
@@ -16,6 +16,13 @@ pub struct User {
 }
 ```
 
+New entities are created with `cargo generate`. The created entity will have a `id` field of type `Uuid`. It is recommended to specify all fields to avoid having to fill them in the generated file manually.
+The command below generates the `User` entity seen above:
+
+```sh
+cargo generate entity user name:String
+```
+
 ## Reading and writing data
 
 Instead of using an ORM, that would introduce additional complexity, Gerust uses individual functions for reading and writing data from and to the database, e.g.:

--- a/blueprint/db/README.md
+++ b/blueprint/db/README.md
@@ -16,8 +16,7 @@ pub struct User {
 }
 ```
 
-New entities are created with `cargo generate`. The created entity will have a `id` field of type `Uuid`. It is recommended to specify all fields to avoid having to fill them in the generated file manually.
-The command below generates the `User` entity seen above:
+New entities are created with `cargo generate`. The created entity will have an `id` field of type `Uuid`. You can also specify additional fields. The command below generates the `User` entity seen above:
 
 ```sh
 cargo generate entity user name:String


### PR DESCRIPTION
This PR better documents `cargo generate entity` in the `db` README and in `cargo generate entity --help` 