### PR TITLE
docs: Clarify that the generated migrations are empty

### DIFF
--- a/blueprint/cli/src/bin/generate.rs
+++ b/blueprint/cli/src/bin/generate.rs
@@ -147,12 +147,13 @@ fn cli(ui: &mut UI<'_>, cli: Cli) -> Result<(), anyhow::Error> {
             if simple {
                 let file_name = generate_simple_migration(&name, cli.r#override)
                     .context("Could not generate migration!")?;
-                ui.success(&format!("Generated migration {}.", file_name.display()));
+                ui.success(&format!("Generated empty migration {}.", file_name.display()));
             } else {
                 let (up_file_name, down_file_name) = generate_migration(&name, cli.r#override)
                     .context("Could not generate migration!")?;
-                ui.success(&format!("Generated migration {}.", up_file_name.display()));
-                ui.success(&format!("Generated migration {}.", down_file_name.display()));
+                ui.success(&format!("Generated empty migration {}.", up_file_name.display()));
+                ui.success(&format!("Generated empty migration {}.", down_file_name.display()));
+                ui.info("Fill the migration with your own SQL statements.")
             }
             Ok(())
         }

--- a/blueprint/db/README.md
+++ b/blueprint/db/README.md
@@ -116,7 +116,9 @@ The `db` crate also comes with a dedicate module for additional helpers that onl
 
 ## Migrations
 
-Migrations are stored as plain SQL files under `migrations`. In order to maintain a stable order, migrations are sorted by creation date – the [`migration` generator](../cli/README.md) will automatically generate files with the correct prefix.
+Migrations are stored as plain SQL files under `migrations`.
+To maintain a stable order, migrations are sorted by creation date – the [`migration` generator](../cli/README.md) will automatically generate files with the correct prefix.
+The generator creates empty migration files, it is up to the developer to fill them with SQL statements.
 
 [`fake`]: https://crates.io/crates/fake "fake on crates.io"
 [`sqlx`]: https://crates.io/crates/sqlx "SQLx on crates.io"


### PR DESCRIPTION
Add some documentation to inform the user that generated migrations are empty files.

This should prevent users from assuming that their changes to entities are automatically reflected when a migration is generated (as would be the case in #311).